### PR TITLE
Invalidation cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,29 @@
 
 ## Basic
 
-The Ocelot ETag Caching library adds support for ETag caching to the Ocelot API Gateway. ETag caching is a mechanism that allows a client to cache data and the next time the same data is requested, the client can verify that the data is still up to date. If the data is still current, the server will return a status of `304 Not Modified` and the client will use the cached data. If the data is not up-to-date, the server returns the data and the client caches it.
+The Ocelot ETag Caching library adds support for ETag caching to the Ocelot API Gateway.
+ETag caching is a mechanism that allows a client to cache data and the next time the same data is requested,
+the client can verify that the data is still up to date. If the data is still current, the server will return a status
+of `304 Not Modified` and the client will use the cached data. If the data is not up-to-date,
+the server returns the data and the client caches it.
 
 The idea is that the server adds two important headers to the response:
 
 - `ETag` - data identifier (randomly generated value)
 - `cache-control` - identifier that the data can be cached. Contains only the value `private` (⚠️ beware it must not be `public`, because then the data can remain cached anywhere.) It also does not contain `max-age` because in this case the client would not verify the data on the server (for a given amount of time. Occasionally this may be OK).
 
-If the client (browser) finds these two headers in the response, it adds the `If-None-Match` header with the `ETag` value in the next request to the server with the same path and the server knows if the data is still up to date based on this value. If they are up to date it returns a status of `304 Not Modified` and the client uses the data from the cache.
+If the client (browser) finds these two headers in the response, it adds the `If-None-Match` header with the `ETag`
+value in the next request to the server with the same path and the server knows if the data is still up to date
+based on this value. If they are up to date it returns a status of `304 Not Modified` and the client uses the data from the cache.
 **👌 The server does not send the data. This saves resources and bandwidth**
 
 On the client, this works automatically because this behavior is defined in the HTTP specification (no need to do anything).
 
 ## Implementation
 
-The implementation is based on Ocelot middleware. All caching will be done in this middleware and nothing will be needed on the service side. The data itself is not cached, but only its identifier (ETag), based on which the data is verified to be up-to-date.
+The implementation is based on Ocelot middleware. All caching will be done in this middleware and nothing
+will be needed on the service side. The data itself is not cached, but only its identifier (ETag), 
+based on which the data is verified to be up-to-date.
 
 We use `IOutputCacheStore` to store ETags and invalidate them.
 

--- a/README.md
+++ b/README.md
@@ -98,9 +98,41 @@ Tag is created by replacing placeholders with values from request route paramete
 
 For example, for route `/api/{tenantId}/products/{id}` and tag template `product:{tenantId}:{id}` the tag will be `product:1:2`.
 
-> Cache invalidation will be added in the next pull request.
+## Cache invalidation
+
+You can invalidate cache entries by tags defined in tag templates.
+
+### Automatic by endpoints
+
+```json
+{
+    "Key": "deleteProduct",
+    "UpstreamHttpMethod": [ "Delete" ],
+    "DownstreamPathTemplate": "/api/producsts/{id}",
+    "UpstreamPathTemplate": "/products/{id}",
+    "InvalidateCache": ["product:{tenantId}", "product:{tenantId}:{id}"], // 👈 Invalidate cache by tags
+}
+```
+
+### Manual
 
 ```csharp
+public class ProductsService {
+    private readonly IOutputCacheStore _outputCacheStore;
+
+    public ProductsService(IOutputCacheStore outputCacheStore)
+    {
+        _outputCacheStore = outputCacheStore;
+    }
+
+    public async Task DeleteProduct(int tenantId, int id)
+    {
+        // 👇 Invalidate cache by tags
+        await _outputCacheStore.InvalidateAsync($"product:{tenantId}", $"product:{tenantId}:{id}");
+        // ...
+    }
+}
+```
 
 ## Redis
 

--- a/demo/EShop.Gateway/ocelot.json
+++ b/demo/EShop.Gateway/ocelot.json
@@ -4,7 +4,7 @@
             "Key": "getProducts",
             "DownstreamPathTemplate": "/{tenantId}/products/",
             "UpstreamPathTemplate": "/{tenantId}/products/",
-            "UpstreamHttpMethod": [ "Get", "Post", "Put" ],
+            "UpstreamHttpMethod": [ "Get" ],
             "DownstreamHostAndPorts": [
                 {
                     "Host": "eshop.products",
@@ -18,7 +18,7 @@
             "Key": "getProduct",
             "DownstreamPathTemplate": "/{tenantId}/products/{id}",
             "UpstreamPathTemplate": "/{tenantId}/products/{id}",
-            "UpstreamHttpMethod": [ "Get", "Post", "Put" ],
+            "UpstreamHttpMethod": [ "Get" ],
             "DownstreamHostAndPorts": [
                 {
                     "Host": "eshop.products",
@@ -31,7 +31,7 @@
         {
             "DownstreamPathTemplate": "/{tenantId}/products/{everything}",
             "UpstreamPathTemplate": "/withoutcache/{tenantId}/products/{everything}",
-            "UpstreamHttpMethod": [ "Get", "Post", "Put" ],
+            "UpstreamHttpMethod": [ "Get" ],
             "DownstreamHostAndPorts": [
                 {
                     "Host": "eshop.products",
@@ -39,6 +39,34 @@
                 }
             ],
             "SwaggerKey": "products"
+        },
+        {
+            "Key": "createProduct",
+            "DownstreamPathTemplate": "/{tenantId}/products/",
+            "UpstreamPathTemplate": "/{tenantId}/products/",
+            "UpstreamHttpMethod": [ "Post" ],
+            "DownstreamHostAndPorts": [
+                {
+                    "Host": "eshop.products",
+                    "Port": 5200
+                }
+            ],
+            "SwaggerKey": "products",
+            "InvalidateCache": [ "product:{tenantId}" ]
+        },
+        {
+            "Key": "updateProduct",
+            "DownstreamPathTemplate": "/{tenantId}/products/{id}",
+            "UpstreamPathTemplate": "/{tenantId}/products/{id}",
+            "UpstreamHttpMethod": [ "Put" ],
+            "DownstreamHostAndPorts": [
+                {
+                    "Host": "eshop.products",
+                    "Port": 5200
+                }
+            ],
+            "SwaggerKey": "products",
+            "InvalidateCache": [ "product:{tenantId}", "product:{tenantId}:{id}" ]
         }
     ],
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <VersionPrefix>0.0.1</VersionPrefix>
+        <VersionPrefix>1.0.0</VersionPrefix>
         <VersionSuffix></VersionSuffix>
     </PropertyGroup>
 

--- a/src/Kros.Ocelot.ETagCaching/ETagCachingMiddleware.cs
+++ b/src/Kros.Ocelot.ETagCaching/ETagCachingMiddleware.cs
@@ -20,22 +20,39 @@ internal partial class ETagCachingMiddleware(
     private readonly IOptions<ETagCachingOptions> _cachingOptions = cachingOptions;
     private readonly ILogger<ETagCachingMiddleware> _logger = logger;
 
-    public Task InvokeAsync(HttpContext context, Func<Task> next)
+    public async Task InvokeAsync(HttpContext context, Func<Task> next)
     {
         LogMiddlewareStart(context.Request.GetDisplayUrl());
-        if (TryGetPolicy(context, out var policy))
+
+        if (TryGetTagsForInvalidation(context, out var tags))
         {
-            return InvokeCaching(context, policy, next);
+            await InvalidateCache(tags, context.RequestAborted);
         }
 
-        return next();
+        if (TryGetPolicy(context, out var policy))
+        {
+            await InvokeCaching(context, policy, next);
+            return;
+        }
+
+        await next();
+    }
+
+    private async Task InvalidateCache(string[] tags, CancellationToken cancellationToken)
+    {
+        foreach (var tag in tags)
+        {
+            await _cacheStore.EvictByTagAsync(tag, cancellationToken);
+        }
     }
 
     private bool TryGetPolicy(HttpContext context, [NotNullWhen(true)] out IETagCachePolicy? policy)
     {
         var downstreamRoute = context.Items.DownstreamRoute();
 
-        if (!string.IsNullOrWhiteSpace(downstreamRoute.Key) && _routeOptions.TryGetValue(downstreamRoute.Key, out var route))
+        if (!string.IsNullOrWhiteSpace(downstreamRoute.Key)
+            && _routeOptions.TryGetValue(downstreamRoute.Key, out var route)
+            && !string.IsNullOrEmpty(route.CachePolicy))
         {
             policy = _cachingOptions.Value.GetPolicy(route.CachePolicy);
             return true;
@@ -136,6 +153,23 @@ internal partial class ETagCachingMiddleware(
 
         var response = new DownstreamResponse(stringContent, cacheContext.StatusCode, headers, string.Empty);
         context.Items.UpsertDownstreamResponse(response);
+    }
+
+    private bool TryGetTagsForInvalidation(HttpContext context, out string[] tags)
+    {
+        var downstreamRoute = context.Items.DownstreamRoute();
+        tags = [];
+
+        if (!string.IsNullOrWhiteSpace(downstreamRoute.Key)
+            && _routeOptions.TryGetValue(downstreamRoute.Key, out var route)
+            && route.InvalidateCache is not null)
+        {
+            tags = [.. TagsHelper.GetTags([.. route.InvalidateCache], context.Items.TemplatePlaceholderNameAndValues())];
+
+            return tags.Length > 0;
+        }
+
+        return false;
     }
 
     [LoggerMessage("ETagCachingMiddleware start for the request: '{requestPath}'", Level = LogLevel.Debug)]

--- a/src/Kros.Ocelot.ETagCaching/ETagCachingMiddleware.cs
+++ b/src/Kros.Ocelot.ETagCaching/ETagCachingMiddleware.cs
@@ -42,6 +42,7 @@ internal partial class ETagCachingMiddleware(
     {
         foreach (var tag in tags)
         {
+            LogCacheEviction(tag);
             await _cacheStore.EvictByTagAsync(tag, cancellationToken);
         }
     }
@@ -189,4 +190,7 @@ internal partial class ETagCachingMiddleware(
 
     [LoggerMessage("Setting information to cache store: {cacheContext}.", Level = LogLevel.Information)]
     partial void LogSettingToCacheStore(ETagCacheContext cacheContext);
+
+    [LoggerMessage("Cache eviction for tag: {tag}", Level = LogLevel.Information)]
+    partial void LogCacheEviction(string tag);
 }

--- a/src/Kros.Ocelot.ETagCaching/FakeDownstreamRoute.cs
+++ b/src/Kros.Ocelot.ETagCaching/FakeDownstreamRoute.cs
@@ -3,4 +3,4 @@
 [Obsolete(
     "This can be removed when issue https://github.com/ThreeMammals/Ocelot/pull/1843 will be release.",
     DiagnosticId = "KO001")]
-internal record FakeDownstreamRoute(string Key, string CachePolicy);
+internal record FakeDownstreamRoute(string Key, string? CachePolicy = null, HashSet<string>? InvalidateCache = null);

--- a/src/Kros.Ocelot.ETagCaching/Policies/TagTemplatesPolicy.cs
+++ b/src/Kros.Ocelot.ETagCaching/Policies/TagTemplatesPolicy.cs
@@ -8,17 +8,7 @@ internal sealed class TagTemplatesPolicy(string[] tagTemplates) : IETagCachePoli
 
     public ValueTask CacheETagAsync(ETagCacheContext context, CancellationToken cancellationToken)
     {
-        var tagSb = new StringBuilder();
-        foreach (var tagTemplate in _tagTemplates)
-        {
-            tagSb.Append(tagTemplate);
-            foreach (var template in context.TemplatePlaceholderNameAndValues)
-            {
-                tagSb.Replace(template.Name, template.Value);
-            }
-            context.Tags.Add(tagSb.ToString());
-            tagSb.Length = 0;
-        }
+        context.Tags.UnionWith(TagsHelper.GetTags(_tagTemplates, context.TemplatePlaceholderNameAndValues));
 
         return ValueTask.CompletedTask;
     }

--- a/src/Kros.Ocelot.ETagCaching/TagsHelper.cs
+++ b/src/Kros.Ocelot.ETagCaching/TagsHelper.cs
@@ -1,0 +1,25 @@
+﻿using Ocelot.DownstreamRouteFinder.UrlMatcher;
+using System.Text;
+
+namespace Kros.Ocelot.ETagCaching;
+
+internal static class TagsHelper
+{
+    public static HashSet<string> GetTags(string[] tagTemplates, List<PlaceholderNameAndValue> templatePlaceholderNameAndValues)
+    {
+        var tags = new HashSet<string>();
+        var tagSb = new StringBuilder();
+        foreach (var tagTemplate in tagTemplates)
+        {
+            tagSb.Append(tagTemplate);
+            foreach (var template in templatePlaceholderNameAndValues)
+            {
+                tagSb.Replace(template.Name, template.Value);
+            }
+            tags.Add(tagSb.ToString());
+            tagSb.Length = 0;
+        }
+
+        return tags;
+    }
+}

--- a/tests/Kros.Ocelot.ETagCaching.Test/DefaultWebApplicationFactory.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/DefaultWebApplicationFactory.cs
@@ -43,7 +43,7 @@ public class DefaultWebApplicationFactory : WebApplicationFactory<IAssemblyMarke
     {
         var ret = new Dictionary<string, string?>();
 
-        for (var i = 0; i < 3; i++)
+        for (var i = 0; i < 5; i++)
         {
             ret[$"Routes:{i}:DownstreamHostAndPorts:0:Host"] = "localhost";
             ret[$"Routes:{i}:DownstreamHostAndPorts:0:Port"] = WireMockServer.Ports[0].ToString();
@@ -56,5 +56,11 @@ public class DefaultWebApplicationFactory : WebApplicationFactory<IAssemblyMarke
     {
         WireMockServer.Given(Request.Create().WithPath("/1/products").UsingGet())
             .RespondWith(Response.Create().WithBody("this is a body").WithStatusCode(200));
+
+        WireMockServer.Given(Request.Create().WithPath("/2/products").UsingGet())
+            .RespondWith(Response.Create().WithBody("this is a body").WithStatusCode(200));
+
+        WireMockServer.Given(Request.Create().WithPath("/2/products").UsingPost())
+            .RespondWith(Response.Create().WithBody("this is a body").WithStatusCode(201));
     }
 }

--- a/tests/Kros.Ocelot.ETagCaching.Test/ETagCachingMiddlewareShould.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/ETagCachingMiddlewareShould.cs
@@ -358,7 +358,7 @@ public class ETagCachingMiddlewareShould
         context.Items.UpsertTemplatePlaceholderNameAndValues([new("{tenantId}", "2"), new ("{id}", "3")]);
         await middleware.InvokeAsync(context, () => Task.CompletedTask);
 
-        store.EvicedTags.Should().Be("tenant:2:product:3;tenant:2;");
+        store.EvictedTags.Should().Be("tenant:2:product:3;tenant:2;");
     }
 
     private static DownstreamRequest CreateRequest(IEnumerable<(string header, string value)> headers)
@@ -415,7 +415,7 @@ public class ETagCachingMiddlewareShould
 
         public bool WasCallSetAsync { get; private set; }
 
-        public string EvicedTags { get; private set; } = string.Empty;
+        public string EvictedTags { get; private set; } = string.Empty;
 
         public static Store Create(ETagCacheEntry? entry = null)
             => new(entry);
@@ -427,7 +427,7 @@ public class ETagCachingMiddlewareShould
 
         public ValueTask EvictByTagAsync(string tag, CancellationToken cancellationToken)
         {
-            EvicedTags += $"{tag};";
+            EvictedTags += $"{tag};";
             return ValueTask.CompletedTask;
         }
 

--- a/tests/Kros.Ocelot.ETagCaching.Test/ETagCachingMiddlewareShould.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/ETagCachingMiddlewareShould.cs
@@ -343,6 +343,24 @@ public class ETagCachingMiddlewareShould
         logger.ExecuteCount.Should().Be(4);
     }
 
+    [Fact]
+    public async Task InvalidateCacheIfIsConfigured()
+    {
+        var store = Store.Create();
+        var middleware = new ETagCachingMiddleware(
+            CreateRoutes([new("products", "productsPolicy", ["tenant:{tenantId}:product:{id}", "tenant:{tenantId}"])]),
+            store,
+            Options.Create(ETagCachingOptions.Create()
+                .AddPolicy("productsPolicy", (_) => { })),
+            NullLogger<ETagCachingMiddleware>.Instance);
+
+        var context = CreateHttpContext();
+        context.Items.UpsertTemplatePlaceholderNameAndValues([new("{tenantId}", "2"), new ("{id}", "3")]);
+        await middleware.InvokeAsync(context, () => Task.CompletedTask);
+
+        store.EvicedTags.Should().Be("tenant:2:product:3;tenant:2;");
+    }
+
     private static DownstreamRequest CreateRequest(IEnumerable<(string header, string value)> headers)
     {
         var request = new DownstreamRequest(new HttpRequestMessage(HttpMethod.Get, "http://localhost"));
@@ -397,6 +415,8 @@ public class ETagCachingMiddlewareShould
 
         public bool WasCallSetAsync { get; private set; }
 
+        public string EvicedTags { get; private set; } = string.Empty;
+
         public static Store Create(ETagCacheEntry? entry = null)
             => new(entry);
 
@@ -406,7 +426,10 @@ public class ETagCachingMiddlewareShould
         }
 
         public ValueTask EvictByTagAsync(string tag, CancellationToken cancellationToken)
-            => throw new NotImplementedException();
+        {
+            EvicedTags += $"{tag};";
+            return ValueTask.CompletedTask;
+        }
 
         public ValueTask SetAsync(
             string key,


### PR DESCRIPTION
## Cache invalidation

You can invalidate cache entries by tags defined in tag templates.

### Automatic by endpoints

```json
{
    "Key": "deleteProduct",
    "UpstreamHttpMethod": [ "Delete" ],
    "DownstreamPathTemplate": "/api/producsts/{id}",
    "UpstreamPathTemplate": "/products/{id}",
    "InvalidateCache": ["product:{tenantId}", "product:{tenantId}:{id}"], // 👈 Invalidate cache by tags
}
```

### Manual

```csharp
public class ProductsService {
    private readonly IOutputCacheStore _outputCacheStore;

    public ProductsService(IOutputCacheStore outputCacheStore)
    {
        _outputCacheStore = outputCacheStore;
    }

    public async Task DeleteProduct(int tenantId, int id)
    {
        // 👇 Invalidate cache by tags
        await _outputCacheStore.InvalidateAsync($"product:{tenantId}", $"product:{tenantId}:{id}");
        // ...
    }
}
```