### PR TITLE
Change of the method of invalidation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <ItemGroup>
     <!-- Please keep this file organized alphabetically. -->
-    <PackageVersion Include="Ocelot" Version="21.0.1" />
+    <PackageVersion Include="Ocelot" Version="22.0.1" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.12.0" />
     <!-- Please keep this file organized alphabetically. -->
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <ItemGroup>
     <!-- Please keep this file organized alphabetically. -->
-    <PackageVersion Include="Ocelot" Version="23.2.2" />
+    <PackageVersion Include="Ocelot" Version="21.0.1" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.12.0" />
     <!-- Please keep this file organized alphabetically. -->
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ We use `IOutputCacheStore` to store ETags and invalidate them.
             "Key": "deleteProduct",
             "DownstreamPathTemplate": "/api/producsts/{id}",
             "UpstreamPathTemplate": "/products/{id}",
-            "InvalidateCachePolicies": ["getProduct", "getAllProducts"],
+            "InvalidateCachePolicy": "invalidateProductCachePolicy"
             ...
         }
     ]
@@ -118,8 +118,23 @@ You can invalidate cache entries by tags defined in tag templates.
     "UpstreamHttpMethod": [ "Delete" ],
     "DownstreamPathTemplate": "/api/producsts/{id}",
     "UpstreamPathTemplate": "/products/{id}",
-    "InvalidateCache": ["product:{tenantId}", "product:{tenantId}:{id}"], // 👈 Invalidate cache by tags
+    "InvalidateCachePolicy": "invalidateProductCachePolicy", // 👈 Invalidate cache policy
 }
+```
+
+```csharp
+builder.Services.AddOcelotETagCaching(conf =>
+{
+    //...
+    // define cache policy
+    //...
+
+    // 👇 Add invalidate cache policy
+    conf.AddInvalidatePolicy("invalidateProductPolicy", builder =>
+    {
+        builder.TagTemplates("product:{tenantId}", "product:{tenantId}:{id}");
+    });
+});
 ```
 
 ### Manual

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ builder.Services.AddOcelotETagCaching(conf =>
     //...
 
     // 👇 Add invalidate cache policy
-    conf.AddInvalidatePolicy("invalidateProductPolicy", builder =>
+    conf.AddInvalidatePolicy("invalidateProductCachePolicy", builder =>
     {
         builder.TagTemplates("product:{tenantId}", "product:{tenantId}:{id}");
     });

--- a/demo/EShop.Gateway/EShop.Gateway.csproj
+++ b/demo/EShop.Gateway/EShop.Gateway.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
     <PackageReference Include="MMLib.SwaggerForOcelot" Version="8.2.0" />
-    <PackageReference Include="Ocelot" Version="23.2.2" />
+    <PackageReference Include="Ocelot" Version="22.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/demo/EShop.Gateway/Program.cs
+++ b/demo/EShop.Gateway/Program.cs
@@ -23,6 +23,11 @@ builder.Services.AddOcelotETagCaching(conf =>
         builder.Expire(TimeSpan.FromMinutes(10));
         builder.TagTemplates("product:{tenantId}", "product:{tenantId}:{id}", "all:{tenantId}");
     });
+
+    conf.AddInvalidatePolicy("invalidateProductPolicy", builder =>
+    {
+        builder.TagTemplates("product:{tenantId}", "product:{tenantId}:{id}");
+    });
 });
 
 var app = builder.Build();

--- a/demo/EShop.Gateway/ocelot.json
+++ b/demo/EShop.Gateway/ocelot.json
@@ -52,7 +52,7 @@
                 }
             ],
             "SwaggerKey": "products",
-            "InvalidateCache": [ "product:{tenantId}" ]
+            "InvalidateCachePolicy": "invalidateProductPolicy"
         },
         {
             "Key": "updateProduct",
@@ -66,7 +66,7 @@
                 }
             ],
             "SwaggerKey": "products",
-            "InvalidateCache": [ "product:{tenantId}", "product:{tenantId}:{id}" ]
+            "InvalidateCachePolicy": "invalidateProductPolicy"
         }
     ],
 

--- a/demo/EShop.Gateway/ocelot.json
+++ b/demo/EShop.Gateway/ocelot.json
@@ -29,8 +29,20 @@
             "CachePolicy": "getProduct"
         },
         {
-            "DownstreamPathTemplate": "/{tenantId}/products/{everything}",
-            "UpstreamPathTemplate": "/withoutcache/{tenantId}/products/{everything}",
+            "DownstreamPathTemplate": "/{tenantId}/products/{id}",
+            "UpstreamPathTemplate": "/withoutcache/{tenantId}/products/{id}",
+            "UpstreamHttpMethod": [ "Get" ],
+            "DownstreamHostAndPorts": [
+                {
+                    "Host": "eshop.products",
+                    "Port": 5200
+                }
+            ],
+            "SwaggerKey": "products"
+        },
+        {
+            "DownstreamPathTemplate": "/{tenantId}/products/",
+            "UpstreamPathTemplate": "/withoutcache/{tenantId}/products/",
             "UpstreamHttpMethod": [ "Get" ],
             "DownstreamHostAndPorts": [
                 {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <VersionPrefix>1.0.0</VersionPrefix>
+        <VersionPrefix>1.1.0</VersionPrefix>
         <VersionSuffix></VersionSuffix>
     </PropertyGroup>
 

--- a/src/Kros.Ocelot.ETagCaching/FakeDownstreamRoute.cs
+++ b/src/Kros.Ocelot.ETagCaching/FakeDownstreamRoute.cs
@@ -3,4 +3,4 @@
 [Obsolete(
     "This can be removed when issue https://github.com/ThreeMammals/Ocelot/pull/1843 will be release.",
     DiagnosticId = "KO001")]
-internal record FakeDownstreamRoute(string Key, string? CachePolicy = null, HashSet<string>? InvalidateCache = null);
+internal record FakeDownstreamRoute(string Key, string? CachePolicy = null, string? InvalidateCachePolicy = null);

--- a/src/Kros.Ocelot.ETagCaching/IInvalidateCachePolicy.cs
+++ b/src/Kros.Ocelot.ETagCaching/IInvalidateCachePolicy.cs
@@ -1,0 +1,14 @@
+﻿namespace Kros.Ocelot.ETagCaching;
+
+/// <summary>
+/// Interface for policy that can invalidate cache.
+/// </summary>
+public interface IInvalidateCachePolicy
+{
+    /// <summary>
+    /// Invalidates cache based on the context.
+    /// </summary>
+    /// <param name="context">The context for cache invalidation.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+    ValueTask InvalidateCacheAsync(InvalidateCacheContext context, CancellationToken cancellationToken);
+}

--- a/src/Kros.Ocelot.ETagCaching/InvalidateCacheContext.cs
+++ b/src/Kros.Ocelot.ETagCaching/InvalidateCacheContext.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.AspNetCore.Http.Features;
+using Ocelot.DownstreamRouteFinder.UrlMatcher;
+using Ocelot.Request.Middleware;
+
+namespace Kros.Ocelot.ETagCaching;
+
+/// <summary>
+/// Context for invalidating cache.
+/// </summary>
+public sealed class InvalidateCacheContext
+{
+    /// <summary>
+    /// HTTP requests features.
+    /// </summary>
+    public required IFeatureCollection RequestFeatures { get; init; }
+
+    /// <summary>
+    /// DI container services.
+    /// </summary>
+    public required IServiceProvider RequestServices { get; init; }
+
+    /// <summary>
+    /// Downstream route template placeholder names and values (from current request).
+    /// </summary>
+    public required List<PlaceholderNameAndValue> TemplatePlaceholderNameAndValues { get; init; }
+
+    /// <summary>
+    /// Gets the Ocelot downstream request.
+    /// </summary>
+    public required DownstreamRequest DownstreamRequest { get; init; }
+
+    /// <summary>
+    /// Tags for cache invalidation.
+    /// </summary>
+    public HashSet<string> Tags { get; } = [];
+
+    /// <summary>
+    /// Gets or sets a value indicating whether cache invalidation is allowed.
+    /// </summary>
+    public bool AllowCacheInvalidation { get; set; }
+}

--- a/src/Kros.Ocelot.ETagCaching/InvalidateCachePolicyBuilder.cs
+++ b/src/Kros.Ocelot.ETagCaching/InvalidateCachePolicyBuilder.cs
@@ -1,0 +1,53 @@
+﻿using Kros.Ocelot.ETagCaching.Policies;
+
+namespace Kros.Ocelot.ETagCaching;
+
+/// <summary>
+/// Provides helper methods to create <see cref="IInvalidateCachePolicy"/>.
+/// </summary>
+public sealed class InvalidateCachePolicyBuilder
+{
+    private readonly List<IInvalidateCachePolicy> _policies = [];
+
+    /// <summary>
+    /// Adds a policy.
+    /// </summary>
+    /// <param name="policy">Policy</param>
+    public InvalidateCachePolicyBuilder AddPolicy(IInvalidateCachePolicy policy)
+    {
+        _policies.Add(policy);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a policy.
+    /// </summary>
+    /// <typeparam name="TPolicy">Policy type.</typeparam>
+    public InvalidateCachePolicyBuilder AddPolicy<TPolicy>()
+           where TPolicy : IInvalidateCachePolicy, new()
+    {
+        AddPolicy(new TPolicy());
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a policy for invalidating cache based on the tag templates.
+    /// </summary>
+    /// <param name="tagTemplates">The tag templates of the cached response</param>
+    public InvalidateCachePolicyBuilder TagTemplates(params string[] tagTemplates)
+    {
+        AddPolicy(new InvalidateDefaultPolicy(tagTemplates));
+        return this;
+    }
+
+    /// <summary>
+    /// Builds the <see cref="IInvalidateCachePolicy"/>.
+    /// </summary>
+    public IInvalidateCachePolicy Build()
+        => _policies.Count switch
+        {
+            0 => InvalidateEmptyPolicy.Instance,
+            1 => _policies[0],
+            _ => new InvalidateCompositePolicy(_policies)
+        };
+}

--- a/src/Kros.Ocelot.ETagCaching/Policies/InvalidateCompositePolicy.cs
+++ b/src/Kros.Ocelot.ETagCaching/Policies/InvalidateCompositePolicy.cs
@@ -1,0 +1,14 @@
+﻿namespace Kros.Ocelot.ETagCaching.Policies;
+
+internal class InvalidateCompositePolicy(List<IInvalidateCachePolicy> policies) : IInvalidateCachePolicy
+{
+    private readonly List<IInvalidateCachePolicy> _policies = policies;
+
+    public async ValueTask InvalidateCacheAsync(InvalidateCacheContext context, CancellationToken cancellationToken = default)
+    {
+        foreach (var policy in _policies)
+        {
+            await policy.InvalidateCacheAsync(context, cancellationToken);
+        }
+    }
+}

--- a/src/Kros.Ocelot.ETagCaching/Policies/InvalidateDefaultPolicy.cs
+++ b/src/Kros.Ocelot.ETagCaching/Policies/InvalidateDefaultPolicy.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Kros.Ocelot.ETagCaching.Policies;
+
+internal class InvalidateDefaultPolicy(string[] tagTemplates) : IInvalidateCachePolicy
+{
+    private readonly string[] _tagTemplates = tagTemplates;
+
+    public ValueTask InvalidateCacheAsync(InvalidateCacheContext context, CancellationToken cancellationToken)
+    {
+        if (IsModifyMethod(context.DownstreamRequest.Method))
+        {
+            context.Tags.UnionWith(TagsHelper.GetTags(_tagTemplates, context.TemplatePlaceholderNameAndValues));
+            context.AllowCacheInvalidation = true;
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    private static bool IsModifyMethod(string method)
+        => method == HttpMethods.Post || method == HttpMethods.Put || method == HttpMethods.Patch || method == HttpMethods.Delete;
+}

--- a/src/Kros.Ocelot.ETagCaching/Policies/InvalidateEmptyPolicy.cs
+++ b/src/Kros.Ocelot.ETagCaching/Policies/InvalidateEmptyPolicy.cs
@@ -1,0 +1,13 @@
+﻿
+namespace Kros.Ocelot.ETagCaching.Policies;
+
+internal class InvalidateEmptyPolicy : IInvalidateCachePolicy
+{
+    public static IInvalidateCachePolicy Instance { get; } = new InvalidateEmptyPolicy();
+
+    // Stryker disable Block: results in an equivalent mutation
+    public ValueTask InvalidateCacheAsync(InvalidateCacheContext context, CancellationToken cancellationToken)
+    {
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Kros.Ocelot.ETagCaching/Policies/TagTemplatesPolicy.cs
+++ b/src/Kros.Ocelot.ETagCaching/Policies/TagTemplatesPolicy.cs
@@ -1,6 +1,4 @@
-﻿using System.Text;
-
-namespace Kros.Ocelot.ETagCaching.Policies;
+﻿namespace Kros.Ocelot.ETagCaching.Policies;
 
 internal sealed class TagTemplatesPolicy(string[] tagTemplates) : IETagCachePolicy
 {

--- a/tests/Kros.Ocelot.ETagCaching.Test/DefaultWebApplicationFactory.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/DefaultWebApplicationFactory.cs
@@ -54,13 +54,13 @@ public class DefaultWebApplicationFactory : WebApplicationFactory<IAssemblyMarke
 
     private void ConfigureWireMockServer()
     {
-        WireMockServer.Given(Request.Create().WithPath("/1/products").UsingGet())
+        WireMockServer.Given(Request.Create().WithPath("/1/products/").UsingGet())
             .RespondWith(Response.Create().WithBody("this is a body").WithStatusCode(200));
 
-        WireMockServer.Given(Request.Create().WithPath("/2/products").UsingGet())
+        WireMockServer.Given(Request.Create().WithPath("/2/products/").UsingGet())
             .RespondWith(Response.Create().WithBody("this is a body").WithStatusCode(200));
 
-        WireMockServer.Given(Request.Create().WithPath("/2/products").UsingPost())
+        WireMockServer.Given(Request.Create().WithPath("/2/products/").UsingPost())
             .RespondWith(Response.Create().WithBody("this is a body").WithStatusCode(201));
     }
 }

--- a/tests/Kros.Ocelot.ETagCaching.Test/ETagCachingIntegrationTests.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/ETagCachingIntegrationTests.cs
@@ -23,7 +23,7 @@ public class ETagCachingIntegrationTests(DefaultWebApplicationFactory factory)
     {
         using var client = factory.CreateClient();
 
-        using var request = new HttpRequestMessage(HttpMethod.Get, "/1/products");
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/1/products/");
         request.Headers.IfNoneMatch.Add(new EntityTagHeaderValue("\"etag-value\""));
 
         using var response = await client.SendAsync(request);
@@ -46,7 +46,7 @@ public class ETagCachingIntegrationTests(DefaultWebApplicationFactory factory)
     {
         using var client = factory.CreateClient();
 
-        using var response = await client.GetAsync("withoutcache/1/products");
+        using var response = await client.GetAsync("withoutcache/1/products/");
 
         response.EnsureSuccessStatusCode();
         response.Headers.Contains("ETag").Should().BeFalse();
@@ -87,7 +87,7 @@ public class ETagCachingIntegrationTests(DefaultWebApplicationFactory factory)
     {
         using var client = factory.CreateClient();
 
-        using var response = await client.GetAsync("/2/products");
+        using var response = await client.GetAsync("/2/products/");
 
         response.EnsureSuccessStatusCode();
         var etag = response.Headers.ETag!.Tag;
@@ -99,7 +99,7 @@ public class ETagCachingIntegrationTests(DefaultWebApplicationFactory factory)
             Category = "Category",
             Price = 10
         };
-        var createResponse = await client.PostAsJsonAsync("/2/products", product);
+        var createResponse = await client.PostAsJsonAsync("/2/products/", product);
 
         createResponse.EnsureSuccessStatusCode();
 

--- a/tests/Kros.Ocelot.ETagCaching.Test/InvalidateCacheContextFactory.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/InvalidateCacheContextFactory.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Http;
+using Ocelot.DownstreamRouteFinder.UrlMatcher;
+using Ocelot.Request.Middleware;
+
+namespace Kros.Ocelot.ETagCaching.Test;
+
+internal static class InvalidateCacheContextFactory
+{
+    public static InvalidateCacheContext CreateContext(string httpMethod = "POST")
+    {
+        var httpContext = new DefaultHttpContext();
+        var request = new HttpRequestMessage()
+        {
+            Method = new HttpMethod(httpMethod),
+            RequestUri = new Uri("http://localhost:5000/api/2/products?skip=10&take=5")
+        };
+        var context = new InvalidateCacheContext()
+        {
+            RequestFeatures = httpContext.Features,
+            RequestServices = httpContext.RequestServices,
+            TemplatePlaceholderNameAndValues = [],
+            DownstreamRequest = new DownstreamRequest(request)
+        };
+
+        context.TemplatePlaceholderNameAndValues.Add(new PlaceholderNameAndValue("{tenantId}", "1"));
+        context.TemplatePlaceholderNameAndValues.Add(new PlaceholderNameAndValue("{id}", "2"));
+
+        return context;
+    }
+}

--- a/tests/Kros.Ocelot.ETagCaching.Test/InvalidateCachePolicyBuilderShould.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/InvalidateCachePolicyBuilderShould.cs
@@ -1,0 +1,44 @@
+﻿using Kros.Ocelot.ETagCaching.Policies;
+
+namespace Kros.Ocelot.ETagCaching.Test;
+
+public class InvalidateCachePolicyBuilderShould
+{
+    [Fact]
+    public void BuildEmptyPolicy()
+    {
+        var builder = new InvalidateCachePolicyBuilder();
+        var policy = builder.Build();
+
+        policy.Should().BeOfType<InvalidateEmptyPolicy>();
+    }
+
+    [Fact]
+    public void BuildTagTemplatesPolicy()
+    {
+        var builder = new InvalidateCachePolicyBuilder();
+        var policy = builder.TagTemplates("products").Build();
+
+        policy.Should().BeOfType<InvalidateDefaultPolicy>();
+    }
+
+    [Fact]
+    public void BuildCompositePolicy()
+    {
+        var builder = new InvalidateCachePolicyBuilder();
+        var policy = builder
+            .AddPolicy<InvalidateEmptyPolicy>()
+            .AddPolicy<FakePolicy>()
+            .Build();
+
+        policy.Should().BeOfType<InvalidateCompositePolicy>();
+    }
+
+    private class FakePolicy : IInvalidateCachePolicy
+    {
+        public ValueTask InvalidateCacheAsync(InvalidateCacheContext context, CancellationToken cancellationToken)
+        {
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/Kros.Ocelot.ETagCaching.Test/Policies/InvalidateCompositPolicyShould.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/Policies/InvalidateCompositPolicyShould.cs
@@ -1,0 +1,33 @@
+﻿using Kros.Ocelot.ETagCaching.Policies;
+
+namespace Kros.Ocelot.ETagCaching.Test.Policies;
+
+public class InvalidateCompositPolicyShould
+{
+    [Fact]
+    public async Task InvalidateCache()
+    {
+        var context = InvalidateCacheContextFactory.CreateContext();
+        var policy1 = new InvalidateEmptyPolicy();
+        var policy2 = new InvalidateDefaultPolicy(["products"]);
+        var policy = new InvalidateCompositePolicy([policy1, policy2]);
+
+        await policy.InvalidateCacheAsync(context, default);
+
+        context.AllowCacheInvalidation.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InvalidateCacheByAllPolicies()
+    {
+        var context = InvalidateCacheContextFactory.CreateContext();
+        var policy1 = new InvalidateDefaultPolicy(["products"]);
+        var policy2 = new InvalidateDefaultPolicy(["products:{tenantId}", "products:{tenantId}:{id}"]);
+        var policy = new InvalidateCompositePolicy([policy1, policy2]);
+
+        await policy.InvalidateCacheAsync(context, default);
+
+        context.AllowCacheInvalidation.Should().BeTrue();
+        context.Tags.Should().BeEquivalentTo(["products", "products:1", "products:1:2"]);
+    }
+}

--- a/tests/Kros.Ocelot.ETagCaching.Test/Policies/InvalidateDefaultPolicyShould.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/Policies/InvalidateDefaultPolicyShould.cs
@@ -1,0 +1,35 @@
+﻿using Kros.Ocelot.ETagCaching.Policies;
+
+namespace Kros.Ocelot.ETagCaching.Test.Policies;
+
+public class InvalidateDefaultPolicyShould
+{
+    [Theory]
+    [InlineData("GET", false)]
+    [InlineData("POST", true)]
+    [InlineData("PUT", true)]
+    [InlineData("DELETE", true)]
+    [InlineData("PATCH", true)]
+    [InlineData("HEAD", false)]
+    [InlineData("OPTIONS", false)]
+    public async Task SetInvalidatedWhenIsModifyMethod(string method, bool invalidated)
+    {
+        var context = InvalidateCacheContextFactory.CreateContext(method);
+        var policy = new InvalidateDefaultPolicy(["products"]);
+
+        await policy.InvalidateCacheAsync(context, default);
+
+        context.AllowCacheInvalidation.Should().Be(invalidated);
+    }
+
+    [Fact]
+    public async Task AddTagsByTemplate()
+    {
+        var context = InvalidateCacheContextFactory.CreateContext();
+        var policy = new InvalidateDefaultPolicy(["products:{tenantId}", "products:{tenantId}:{id}"]);
+
+        await policy.InvalidateCacheAsync(context, default);
+
+        context.Tags.Should().BeEquivalentTo(["products:1", "products:1:2"]);
+    }
+}

--- a/tests/Kros.Ocelot.ETagCaching.Test/Policies/InvalidateEmptyCachePolicyShould.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/Policies/InvalidateEmptyCachePolicyShould.cs
@@ -1,0 +1,17 @@
+﻿using Kros.Ocelot.ETagCaching.Policies;
+
+namespace Kros.Ocelot.ETagCaching.Test.Policies;
+
+public class InvalidateEmptyCachePolicyShould
+{
+    [Fact]
+    public async Task DoNotInvalidateCache()
+    {
+        var context = InvalidateCacheContextFactory.CreateContext();
+        var policy = new InvalidateEmptyPolicy();
+
+        await policy.InvalidateCacheAsync(context, default);
+
+        context.AllowCacheInvalidation.Should().BeFalse();
+    }
+}

--- a/tests/Kros.Ocelot.ETagCaching.Test/PublicApiTests.Assembly_Has_No_Public_Api_Changes.verified.txt
+++ b/tests/Kros.Ocelot.ETagCaching.Test/PublicApiTests.Assembly_Has_No_Public_Api_Changes.verified.txt
@@ -100,6 +100,6 @@ namespace Kros.Ocelot.ETagCaching
     }
     public static class OcelotPipelineConfigurationExtension
     {
-        public static void AddETagCaching(this Ocelot.Middleware.OcelotPipelineConfiguration pipelineConfiguration) { }
+        public static void AddETagCaching(this Ocelot.Middleware.OcelotPipelineConfiguration pipelineConfiguration, System.Func<Microsoft.AspNetCore.Http.HttpContext, System.Func<System.Threading.Tasks.Task>, System.Threading.Tasks.Task>? preview = null) { }
     }
 }

--- a/tests/Kros.Ocelot.ETagCaching.Test/PublicApiTests.Assembly_Has_No_Public_Api_Changes.verified.txt
+++ b/tests/Kros.Ocelot.ETagCaching.Test/PublicApiTests.Assembly_Has_No_Public_Api_Changes.verified.txt
@@ -52,7 +52,9 @@ namespace Kros.Ocelot.ETagCaching
     {
         public ETagCachingOptions() { }
         public Kros.Ocelot.ETagCaching.ETagCachingOptions AddDefaultPolicy(string policyName) { }
+        public Kros.Ocelot.ETagCaching.ETagCachingOptions AddInvalidatePolicy(string policyName, System.Action<Kros.Ocelot.ETagCaching.InvalidateCachePolicyBuilder> builder) { }
         public Kros.Ocelot.ETagCaching.ETagCachingOptions AddPolicy(string policyName, System.Action<Kros.Ocelot.ETagCaching.ETagCachePolicyBuilder> builder, bool excludeDefaultPolicy = false) { }
+        public Kros.Ocelot.ETagCaching.IInvalidateCachePolicy GetInvalidatePolicy(string policyName) { }
         public Kros.Ocelot.ETagCaching.IETagCachePolicy GetPolicy(string policyName) { }
     }
     public interface IETagCachePolicy
@@ -64,6 +66,37 @@ namespace Kros.Ocelot.ETagCaching
     public interface IETagCachingMiddleware
     {
         System.Threading.Tasks.Task InvokeAsync(Microsoft.AspNetCore.Http.HttpContext context, System.Func<System.Threading.Tasks.Task> next);
+    }
+    public interface IInvalidateCachePolicy
+    {
+        System.Threading.Tasks.ValueTask InvalidateCacheAsync(Kros.Ocelot.ETagCaching.InvalidateCacheContext context, System.Threading.CancellationToken cancellationToken);
+    }
+    [System.Runtime.CompilerServices.RequiredMember]
+    public sealed class InvalidateCacheContext
+    {
+        [System.Obsolete("Constructors of types with required members are not supported in this version of " +
+            "your compiler.", true)]
+        [System.Runtime.CompilerServices.CompilerFeatureRequired("RequiredMembers")]
+        public InvalidateCacheContext() { }
+        public bool AllowCacheInvalidation { get; set; }
+        public System.Collections.Generic.HashSet<string> Tags { get; }
+        [System.Runtime.CompilerServices.RequiredMember]
+        public Ocelot.Request.Middleware.DownstreamRequest DownstreamRequest { get; init; }
+        [System.Runtime.CompilerServices.RequiredMember]
+        public Microsoft.AspNetCore.Http.Features.IFeatureCollection RequestFeatures { get; init; }
+        [System.Runtime.CompilerServices.RequiredMember]
+        public System.IServiceProvider RequestServices { get; init; }
+        [System.Runtime.CompilerServices.RequiredMember]
+        public System.Collections.Generic.List<Ocelot.DownstreamRouteFinder.UrlMatcher.PlaceholderNameAndValue> TemplatePlaceholderNameAndValues { get; init; }
+    }
+    public sealed class InvalidateCachePolicyBuilder
+    {
+        public InvalidateCachePolicyBuilder() { }
+        public Kros.Ocelot.ETagCaching.InvalidateCachePolicyBuilder AddPolicy(Kros.Ocelot.ETagCaching.IInvalidateCachePolicy policy) { }
+        public Kros.Ocelot.ETagCaching.InvalidateCachePolicyBuilder AddPolicy<TPolicy>()
+            where TPolicy : Kros.Ocelot.ETagCaching.IInvalidateCachePolicy, new () { }
+        public Kros.Ocelot.ETagCaching.IInvalidateCachePolicy Build() { }
+        public Kros.Ocelot.ETagCaching.InvalidateCachePolicyBuilder TagTemplates(params string[] tagTemplates) { }
     }
     public static class OcelotPipelineConfigurationExtension
     {


### PR DESCRIPTION
A single invalidation based on defining tags in the ocelot configuration was not enough. Because the configuration for `GET` / `POST` / `...` associated in one general route. So I created a policy based invalidation method, where the base policy has a condition for modifiable `HTTP` methods.

```json
{
    "Key": "deleteProduct",
    "UpstreamHttpMethod": [ "Delete" ],
    "DownstreamPathTemplate": "/api/producsts/{id}",
    "UpstreamPathTemplate": "/products/{id}",
    "InvalidateCachePolicy": "invalidateProductCachePolicy", // 👈 Invalidate cache policy
}
```

```csharp
builder.Services.AddOcelotETagCaching(conf =>
{
    //...
    // define cache policy
    //...

    // 👇 Add invalidate cache policy
    conf.AddInvalidatePolicy("invalidateProductPolicy", builder =>
    {
        builder.TagTemplates("product:{tenantId}", "product:{tenantId}:{id}");
    });
});
```

---

Downgrade Ocelot to `22.0.1` because https://github.com/ThreeMammals/Ocelot/issues/2064#event-12770586489