### PR TITLE
Upstream cache key

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,9 +11,9 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET Core if needed
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version:  8.0.x
     - name: Set execute permission for build.sh
@@ -36,7 +36,7 @@ jobs:
     - name: Stryker
       run: ./build.sh --target MutationTest --configuration Release
     - name: Upload Stryker Results as Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: stryker-results
         path: '**/StrykerOutput/**/*.html'
@@ -46,9 +46,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup .NET Core if needed
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version:  8.0.x
       - name: Set execute permission for build.sh

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,31 +1,52 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "$ref": "#/definitions/build",
-  "title": "Build Schema",
   "definitions": {
-    "build": {
-      "type": "object",
+    "Host": {
+      "type": "string",
+      "enum": [
+        "AppVeyor",
+        "AzurePipelines",
+        "Bamboo",
+        "Bitbucket",
+        "Bitrise",
+        "GitHubActions",
+        "GitLab",
+        "Jenkins",
+        "Rider",
+        "SpaceAutomation",
+        "TeamCity",
+        "Terminal",
+        "TravisCI",
+        "VisualStudio",
+        "VSCode"
+      ]
+    },
+    "ExecutableTarget": {
+      "type": "string",
+      "enum": [
+        "AffectedProjects",
+        "Clean",
+        "Compile",
+        "MutationTest",
+        "Pack",
+        "PrintTestResults",
+        "Push",
+        "Restore",
+        "Test"
+      ]
+    },
+    "Verbosity": {
+      "type": "string",
+      "description": "",
+      "enum": [
+        "Verbose",
+        "Normal",
+        "Minimal",
+        "Quiet"
+      ]
+    },
+    "NukeBuild": {
       "properties": {
-        "AffectedFrom": {
-          "type": "string",
-          "description": "A branch or commit to compare against --affected-to when using --affected-only"
-        },
-        "AffectedOnly": {
-          "type": "boolean",
-          "description": "Build/test only projects affected by changes between --affected-from and --affected-to"
-        },
-        "AffectedTo": {
-          "type": "string",
-          "description": "A branch or commit to compare against --affected-from when using --affected-only"
-        },
-        "Configuration": {
-          "type": "string",
-          "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
-          "enum": [
-            "Debug",
-            "Release"
-          ]
-        },
         "Continue": {
           "type": "boolean",
           "description": "Indicates to continue a previously failed build attempt"
@@ -35,37 +56,12 @@
           "description": "Shows the help text for this build assembly"
         },
         "Host": {
-          "type": "string",
           "description": "Host for execution. Default is 'automatic'",
-          "enum": [
-            "AppVeyor",
-            "AzurePipelines",
-            "Bamboo",
-            "Bitbucket",
-            "Bitrise",
-            "GitHubActions",
-            "GitLab",
-            "Jenkins",
-            "Rider",
-            "SpaceAutomation",
-            "TeamCity",
-            "Terminal",
-            "TravisCI",
-            "VisualStudio",
-            "VSCode"
-          ]
+          "$ref": "#/definitions/Host"
         },
         "NoLogo": {
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"
-        },
-        "NugetApiKey": {
-          "type": "string",
-          "description": "Nuget API Key for this source"
-        },
-        "NugetApiUrl": {
-          "type": "string",
-          "description": "Nuget API Url"
         },
         "Partition": {
           "type": "string",
@@ -90,57 +86,66 @@
           "type": "array",
           "description": "List of targets to be skipped. Empty list skips all dependencies",
           "items": {
-            "type": "string",
-            "enum": [
-              "AffectedProjects",
-              "Clean",
-              "Compile",
-              "MutationTest",
-              "Pack",
-              "PrintTestResults",
-              "Push",
-              "Restore",
-              "Test"
-            ]
+            "$ref": "#/definitions/ExecutableTarget"
           }
-        },
-        "Solution": {
-          "type": "string",
-          "description": "Path to a solution file that is automatically loaded"
         },
         "Target": {
           "type": "array",
           "description": "List of targets to be invoked. Default is '{default_target}'",
           "items": {
-            "type": "string",
-            "enum": [
-              "AffectedProjects",
-              "Clean",
-              "Compile",
-              "MutationTest",
-              "Pack",
-              "PrintTestResults",
-              "Push",
-              "Restore",
-              "Test"
-            ]
+            "$ref": "#/definitions/ExecutableTarget"
           }
+        },
+        "Verbosity": {
+          "description": "Logging verbosity during build execution. Default is 'Normal'",
+          "$ref": "#/definitions/Verbosity"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "properties": {
+        "AffectedFrom": {
+          "type": "string",
+          "description": "A branch or commit to compare against --affected-to when using --affected-only"
+        },
+        "AffectedOnly": {
+          "type": "boolean",
+          "description": "Build/test only projects affected by changes between --affected-from and --affected-to"
+        },
+        "AffectedTo": {
+          "type": "string",
+          "description": "A branch or commit to compare against --affected-from when using --affected-only"
+        },
+        "Configuration": {
+          "type": "string",
+          "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
+          "enum": [
+            "Debug",
+            "Release"
+          ]
+        },
+        "NugetApiKey": {
+          "type": "string",
+          "description": "Nuget API Key for this source"
+        },
+        "NugetApiUrl": {
+          "type": "string",
+          "description": "Nuget API Url"
+        },
+        "Solution": {
+          "type": "string",
+          "description": "Path to a solution file that is automatically loaded"
         },
         "TestResultsDirectory": {
           "type": "string",
           "description": "Output directory for test results"
-        },
-        "Verbosity": {
-          "type": "string",
-          "description": "Logging verbosity during build execution. Default is 'Normal'",
-          "enum": [
-            "Minimal",
-            "Normal",
-            "Quiet",
-            "Verbose"
-          ]
         }
       }
+    },
+    {
+      "$ref": "#/definitions/NukeBuild"
     }
-  }
+  ]
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
         <PackageVersion Include="AutoBogus.Conventions" Version="2.13.1" />
         <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
         <PackageVersion Include="MMLib.SwaggerForOcelot" Version="8.2.0" />
-        <PackageVersion Include="Nuke.Common" Version="8.0.0" />
+        <PackageVersion Include="Nuke.Common" Version="[8.0.0]" />
         <PackageVersion Include="Ocelot" Version="22.0.1" />
         <PackageVersion Include="Roslynator.Analyzers" Version="4.12.0" />
         <PackageVersion Include="Spectre.Console" Version="0.48.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
         <PackageVersion Include="AutoBogus.Conventions" Version="2.13.1" />
         <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
         <PackageVersion Include="MMLib.SwaggerForOcelot" Version="8.2.0" />
-        <PackageVersion Include="Nuke.Common" Version="[8.0.0]" />
+        <PackageVersion Include="Nuke.Common" Version="9.0.4" />
         <PackageVersion Include="Ocelot" Version="22.0.1" />
         <PackageVersion Include="Roslynator.Analyzers" Version="4.12.0" />
         <PackageVersion Include="Spectre.Console" Version="0.48.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,7 @@
         <!-- Please keep this file organized alphabetically. -->
         <PackageVersion Include="AutoBogus.Conventions" Version="2.13.1" />
         <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
-        <PackageVersion Include="MMLib.SwaggerForOcelot" Version="8.2.0" />
-        <PackageVersion Include="Nuke.Common" Version="9.0.4" />
+        <PackageVersion Include="MMLib.SwaggerForOcelot" Version="8.2.0" />        
         <PackageVersion Include="Ocelot" Version="22.0.1" />
         <PackageVersion Include="Roslynator.Analyzers" Version="4.12.0" />
         <PackageVersion Include="Spectre.Console" Version="0.48.0" />

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ p.CacheKey(downstreamRequest => $"custom:{downstreamRequest.Method}:{downstreamR
 Uses the original request before Ocelot transformation (upstream request):
 
 ```csharp
-// Default upstream cache key (method:scheme:host:path:query)
+// Default upstream cache key (method:scheme:host:port:path:query)
 p.UpstreamCacheKey();
 
 // Custom upstream cache key generator

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -3,7 +3,6 @@ using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
-using Nuke.Common.Tools.GitVersion;
 using Nuke.Common.Utilities.Collections;
 using Serilog;
 using Spectre.Console;
@@ -59,7 +58,8 @@ partial class Build : NukeBuild
         {
             DotNetRestore(s => s
                 .SetProjectFile(Solution)
-                .When(AffectedOnly, ss => ss.SetProjectFile(AffectedProjectPath)));
+                .When(_ => AffectedOnly,
+                    ss => ss.SetProjectFile(AffectedProjectPath)));
         });
 
     Target Compile => _ => _
@@ -72,7 +72,7 @@ partial class Build : NukeBuild
                 .SetConfiguration(Configuration)
                 .SetProjectFile(Solution)
                 .AddProperty("TreatWarningsAsErrors", true)
-                .When(AffectedOnly, ss => ss.SetProjectFile(AffectedProjectPath))
+                .When(_ => AffectedOnly, ss => ss.SetProjectFile(AffectedProjectPath))
                 .EnableNoRestore());
         });
 
@@ -86,7 +86,7 @@ partial class Build : NukeBuild
                 .SetProjectFile(Solution)
                 .AddLoggers("trx")
                 .SetResultsDirectory(TestResultsDirectory)
-                .When(AffectedOnly, ss => ss.SetProjectFile(AffectedProjectPath))
+                .When(_ => AffectedOnly, ss => ss.SetProjectFile(AffectedProjectPath))
                 .EnableNoBuild());
         });
 
@@ -111,7 +111,8 @@ partial class Build : NukeBuild
                     .EnableNoRestore()
                     .SetNoDependencies(true)
                     .SetOutputDirectory(OutputDirectory)
-                    .When(IsDebug, ss => ss.SetVersionSuffix(Environment.MachineName))));
+                    .When(_ => IsDebug,
+                        ss => ss.SetVersionSuffix(Environment.MachineName))));
         });
 
     Target Push => _ => _

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" />
-    <PackageReference Include="Spectre.Console" />
+    <PackageReference Include="Nuke.Common" Version="9.0.4" />
+    <PackageReference Include="Spectre.Console" Version="0.50.0" />
   </ItemGroup>
 
 </Project>

--- a/demo/EShop.Gateway/EShop.Gateway.csproj
+++ b/demo/EShop.Gateway/EShop.Gateway.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>

--- a/demo/EShop.Products/EShop.Products.csproj
+++ b/demo/EShop.Products/EShop.Products.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <VersionPrefix>1.2.0</VersionPrefix>
+        <VersionPrefix>1.3.0</VersionPrefix>
         <VersionSuffix></VersionSuffix>
     </PropertyGroup>
 

--- a/src/Kros.Ocelot.ETagCaching/ETagCacheContext.cs
+++ b/src/Kros.Ocelot.ETagCaching/ETagCacheContext.cs
@@ -25,6 +25,11 @@ public sealed class ETagCacheContext
     public required IServiceProvider RequestServices { get; init; }
 
     /// <summary>
+    /// Gets the original HTTP context (before Ocelot transformation).
+    /// </summary>
+    public required HttpContext HttpContext { get; init; }
+
+    /// <summary>
     /// Downstream route template placeholder names and values (from current request).
     /// </summary>
     public required List<PlaceholderNameAndValue> TemplatePlaceholderNameAndValues { get; init; }

--- a/src/Kros.Ocelot.ETagCaching/ETagCachePolicyBuilder.cs
+++ b/src/Kros.Ocelot.ETagCaching/ETagCachePolicyBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using Kros.Ocelot.ETagCaching.Policies;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Net.Http.Headers;
 using Ocelot.Request.Middleware;
 
@@ -77,6 +78,25 @@ public sealed class ETagCachePolicyBuilder
     public ETagCachePolicyBuilder CacheKey(Func<DownstreamRequest, string> keyGenerator)
     {
         AddPolicy(new CacheKeyPolicy(keyGenerator));
+        return this;
+    }
+
+    /// <summary>
+    /// Add a policy to change the cache key based on upstream HTTP request (before Ocelot transformation).
+    /// </summary>
+    /// <param name="keyGenerator">Cache key generator.</param>
+    public ETagCachePolicyBuilder UpstreamCacheKey(Func<HttpRequest, string> keyGenerator)
+    {
+        AddPolicy(CacheKeyPolicy.FromUpstreamRequest(keyGenerator));
+        return this;
+    }
+
+    /// <summary>
+    /// Add a policy to change the cache key based on upstream HTTP request with default key generation.
+    /// </summary>
+    public ETagCachePolicyBuilder UpstreamCacheKey()
+    {
+        AddPolicy(CacheKeyPolicy.FromUpstreamRequest());
         return this;
     }
 

--- a/src/Kros.Ocelot.ETagCaching/ETagCachingMiddleware.cs
+++ b/src/Kros.Ocelot.ETagCaching/ETagCachingMiddleware.cs
@@ -175,6 +175,7 @@ internal partial class ETagCachingMiddleware(
         DownstreamRequest = context.Items.DownstreamRequest(),
         RequestFeatures = context.Features,
         RequestServices = context.RequestServices,
+        HttpContext = context,
         TemplatePlaceholderNameAndValues = context.Items.TemplatePlaceholderNameAndValues()
     };
 

--- a/src/Kros.Ocelot.ETagCaching/Policies/CacheKeyGenerator.cs
+++ b/src/Kros.Ocelot.ETagCaching/Policies/CacheKeyGenerator.cs
@@ -39,15 +39,15 @@ internal static class CacheKeyGenerator
     {
         const char delimiter = ':';
         var sb = new StringBuilder();
-        sb.Append(method.ToLower());
+        sb.Append(method.ToLowerInvariant());
         sb.Append(delimiter);
-        sb.Append(scheme.ToLower());
+        sb.Append(scheme.ToLowerInvariant());
         sb.Append(delimiter);
-        sb.Append(host.ToLower());
+        sb.Append(host.ToLowerInvariant());
         sb.Append(delimiter);
-        sb.Append(path.ToLower());
+        sb.Append(path.ToLowerInvariant());
         sb.Append(delimiter);
-        sb.Append(query.ToLower());
+        sb.Append(query.ToLowerInvariant());
 
         return sb.ToString();
     }

--- a/src/Kros.Ocelot.ETagCaching/Policies/CacheKeyGenerator.cs
+++ b/src/Kros.Ocelot.ETagCaching/Policies/CacheKeyGenerator.cs
@@ -1,0 +1,54 @@
+using Microsoft.AspNetCore.Http;
+using Ocelot.Request.Middleware;
+using System.Text;
+
+namespace Kros.Ocelot.ETagCaching.Policies;
+
+/// <summary>
+/// Utility class for generating cache keys from different request types.
+/// </summary>
+internal static class CacheKeyGenerator
+{
+    /// <summary>
+    /// Creates a cache key from downstream request (after Ocelot transformation).
+    /// </summary>
+    /// <param name="request">The downstream request.</param>
+    /// <returns>Generated cache key.</returns>
+    public static string CreateFromDownstreamRequest(DownstreamRequest request) =>
+        CreateCacheKey(request.Method, request.Scheme, request.Host, request.AbsolutePath, request.Query);
+
+    /// <summary>
+    /// Creates a cache key from upstream HTTP request (before Ocelot transformation).
+    /// </summary>
+    /// <param name="request">The upstream HTTP request.</param>
+    /// <returns>Generated cache key.</returns>
+    public static string CreateFromUpstreamRequest(HttpRequest request) =>
+        CreateCacheKey(request.Method, request.Scheme, request.Host.ToString(),
+            request.Path.ToString(), request.QueryString.ToString());
+
+    /// <summary>
+    /// Creates a cache key from individual request components.
+    /// </summary>
+    /// <param name="method">HTTP method.</param>
+    /// <param name="scheme">Request scheme (http/https).</param>
+    /// <param name="host">Request host.</param>
+    /// <param name="path">Request path.</param>
+    /// <param name="query">Request query string.</param>
+    /// <returns>Generated cache key in format: method:scheme:host:path:query</returns>
+    private static string CreateCacheKey(string method, string scheme, string host, string path, string query)
+    {
+        const char delimiter = ':';
+        var sb = new StringBuilder();
+        sb.Append(method.ToLower());
+        sb.Append(delimiter);
+        sb.Append(scheme.ToLower());
+        sb.Append(delimiter);
+        sb.Append(host.ToLower());
+        sb.Append(delimiter);
+        sb.Append(path.ToLower());
+        sb.Append(delimiter);
+        sb.Append(query.ToLower());
+
+        return sb.ToString();
+    }
+}

--- a/src/Kros.Ocelot.ETagCaching/Policies/CacheKeyPolicy.cs
+++ b/src/Kros.Ocelot.ETagCaching/Policies/CacheKeyPolicy.cs
@@ -1,14 +1,25 @@
-﻿using Ocelot.Request.Middleware;
+﻿using Microsoft.AspNetCore.Http;
+using Ocelot.Request.Middleware;
 
 namespace Kros.Ocelot.ETagCaching.Policies;
 
-internal sealed class CacheKeyPolicy(Func<DownstreamRequest, string> keyGenerator) : IETagCachePolicy
+internal sealed class CacheKeyPolicy : IETagCachePolicy
 {
-    private readonly Func<DownstreamRequest, string> _keyGenerator = keyGenerator;
+    private readonly Func<ETagCacheContext, string> _keyGenerator;
+
+    public CacheKeyPolicy(Func<DownstreamRequest, string> keyGenerator)
+    {
+        _keyGenerator = context => keyGenerator(context.DownstreamRequest);
+    }
+
+    private CacheKeyPolicy(Func<ETagCacheContext, string> keyGenerator)
+    {
+        _keyGenerator = keyGenerator;
+    }
 
     public ValueTask CacheETagAsync(ETagCacheContext context, CancellationToken cancellationToken)
     {
-        context.CacheKey = _keyGenerator(context.DownstreamRequest);
+        context.CacheKey = _keyGenerator(context);
         return ValueTask.CompletedTask;
     }
 
@@ -21,5 +32,22 @@ internal sealed class CacheKeyPolicy(Func<DownstreamRequest, string> keyGenerato
     public ValueTask ServeDownstreamResponseAsync(ETagCacheContext context, CancellationToken cancellationToken)
     {
         return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Creates a cache key policy based on upstream HTTP request (before Ocelot transformation).
+    /// </summary>
+    /// <param name="keyGenerator">Custom key generator function.</param>
+    internal static CacheKeyPolicy FromUpstreamRequest(Func<HttpRequest, string> keyGenerator)
+    {
+        return new CacheKeyPolicy(context => keyGenerator(context.HttpContext.Request));
+    }
+
+    /// <summary>
+    /// Creates a cache key policy with default upstream request key generation.
+    /// </summary>
+    internal static CacheKeyPolicy FromUpstreamRequest()
+    {
+        return FromUpstreamRequest(CacheKeyGenerator.CreateFromUpstreamRequest);
     }
 }

--- a/src/Kros.Ocelot.ETagCaching/Policies/DefaultPolicy.cs
+++ b/src/Kros.Ocelot.ETagCaching/Policies/DefaultPolicy.cs
@@ -2,7 +2,6 @@
 using Microsoft.Net.Http.Headers;
 using Ocelot.Request.Middleware;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 
 namespace Kros.Ocelot.ETagCaching.Policies;
 
@@ -12,7 +11,7 @@ internal sealed class DefaultPolicy : IETagCachePolicy
     {
     }
 
-    public static DefaultPolicy Instance { get; } = new DefaultPolicy();
+    public static DefaultPolicy Instance { get; } = new();
 
     public ValueTask CacheETagAsync(ETagCacheContext context, CancellationToken cancellationToken)
     {
@@ -88,22 +87,8 @@ internal sealed class DefaultPolicy : IETagCachePolicy
     private static bool IsGetMethod(ETagCacheContext context)
         => context.DownstreamRequest.Method == HttpMethods.Get;
 
-    private static string CreateCacheKey(DownstreamRequest downstreamRequest)
-    {
-        const char delimiter = ':';
-        var sb = new StringBuilder();
-        sb.Append(downstreamRequest.Method.ToLower());
-        sb.Append(delimiter);
-        sb.Append(downstreamRequest.Scheme.ToLower());
-        sb.Append(delimiter);
-        sb.Append(downstreamRequest.Host.ToLower());
-        sb.Append(delimiter);
-        sb.Append(downstreamRequest.AbsolutePath.ToLower());
-        sb.Append(delimiter);
-        sb.Append(downstreamRequest.Query.ToLower());
-
-        return sb.ToString();
-    }
+    private static string CreateCacheKey(DownstreamRequest downstreamRequest) =>
+        CacheKeyGenerator.CreateFromDownstreamRequest(downstreamRequest);
 
     private static bool AllowServeFromCache(ETagCacheContext context, [NotNullWhen(true)] out EntityTagHeaderValue? entityTag)
     {

--- a/tests/Kros.Ocelot.ETagCaching.Test/ETagCacheContextFactory.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/ETagCacheContextFactory.cs
@@ -12,9 +12,20 @@ internal static class ETagCacheContextFactory
     public static ETagCacheContext CreateContext(
         string httpMethod = "GET",
         HttpStatusCode statusCode = HttpStatusCode.OK,
-        string etagValue = "default")
+        string etagValue = "default",
+        string? upstreamPath = null,
+        string? upstreamQuery = null)
     {
-        var httpContext = new DefaultHttpContext();
+        var httpContext = new DefaultHttpContext { Request =
+            {
+                Method = httpMethod,
+                Scheme = "http",
+                Host = new HostString("localhost:5000"),
+                Path = upstreamPath ?? "/api/1/products",
+                QueryString = new QueryString(upstreamQuery ?? "?skip=10&take=5")
+            }
+        };
+
         var request = new HttpRequestMessage()
         {
             Method = new HttpMethod(httpMethod),
@@ -24,6 +35,7 @@ internal static class ETagCacheContextFactory
         {
             RequestFeatures = httpContext.Features,
             RequestServices = httpContext.RequestServices,
+            HttpContext = httpContext,
             TemplatePlaceholderNameAndValues = [],
             DownstreamRequest = new DownstreamRequest(request),
             DownstreamResponse = new DownstreamResponse(new HttpResponseMessage(statusCode)),

--- a/tests/Kros.Ocelot.ETagCaching.Test/Policies/CacheControlPolicyShould.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/Policies/CacheControlPolicyShould.cs
@@ -55,6 +55,7 @@ public class CacheControlPolicyShould
         await defaultPolicy.CacheETagAsync(context2, default);
         await policy.CacheETagAsync(context2, default);
 
-        context.Should().BeEquivalentTo(context2);
+        context.Should().BeEquivalentTo(context2, o =>
+            o.Excluding(p => p.HttpContext));
     }
 }

--- a/tests/Kros.Ocelot.ETagCaching.Test/Policies/CacheEntryEstraPropsPolicyShould.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/Policies/CacheEntryEstraPropsPolicyShould.cs
@@ -63,7 +63,8 @@ public class CacheEntryEstraPropsPolicyShould
         await defaultPolicy.ServeNotModifiedAsync(context2, default);
         await extraPropsPolicy.ServeNotModifiedAsync(context2, default);
 
-        context.Should().BeEquivalentTo(context2);
+        context.Should().BeEquivalentTo(context2, o =>
+            o.Excluding(p => p.HttpContext));
     }
 
     [Fact]
@@ -82,6 +83,7 @@ public class CacheEntryEstraPropsPolicyShould
         context.Should().BeEquivalentTo(context2,
             options => options
                 .Excluding(p => p.ResponseHeaders)
-                .Excluding(p => p.ETag));
+                .Excluding(p => p.ETag)
+                .Excluding(p => p.HttpContext));
     }
 }

--- a/tests/Kros.Ocelot.ETagCaching.Test/Policies/CacheKeyGeneratorShould.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/Policies/CacheKeyGeneratorShould.cs
@@ -1,0 +1,167 @@
+using Kros.Ocelot.ETagCaching.Policies;
+using Microsoft.AspNetCore.Http;
+using Ocelot.Request.Middleware;
+
+namespace Kros.Ocelot.ETagCaching.Test.Policies;
+
+public class CacheKeyGeneratorShould
+{
+    [Fact]
+    public void CreateFromDownstreamRequest_ShouldGenerateCorrectKey()
+    {
+        var request = new HttpRequestMessage()
+        {
+            Method = HttpMethod.Get,
+            RequestUri = new Uri("https://api.example.com/products?category=electronics&page=1")
+        };
+        var downstreamRequest = new DownstreamRequest(request);
+
+        var result = CacheKeyGenerator.CreateFromDownstreamRequest(downstreamRequest);
+
+        result.Should().Be("get:https:api.example.com:/products:?category=electronics&page=1");
+    }
+
+    [Fact]
+    public void CreateFromUpstreamRequest_ShouldGenerateCorrectKey()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Method = "POST";
+        httpContext.Request.Scheme = "http";
+        httpContext.Request.Host = new HostString("localhost:5000");
+        httpContext.Request.Path = "/api/v1/orders";
+        httpContext.Request.QueryString = new QueryString("?include=details&format=json");
+
+        var result = CacheKeyGenerator.CreateFromUpstreamRequest(httpContext.Request);
+
+        result.Should().Be("post:http:localhost:5000:/api/v1/orders:?include=details&format=json");
+    }
+
+    [Fact]
+    public void CreateFromDownstreamRequest_ShouldHandleEmptyQuery()
+    {
+        var request = new HttpRequestMessage()
+        {
+            Method = HttpMethod.Delete,
+            RequestUri = new Uri("https://api.example.com/users/123")
+        };
+        var downstreamRequest = new DownstreamRequest(request);
+
+        var result = CacheKeyGenerator.CreateFromDownstreamRequest(downstreamRequest);
+
+        result.Should().Be("delete:https:api.example.com:/users/123:");
+    }
+
+    [Fact]
+    public void CreateFromUpstreamRequest_ShouldHandleEmptyQuery()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Method = "PUT";
+        httpContext.Request.Scheme = "https";
+        httpContext.Request.Host = new HostString("api.myapp.com");
+        httpContext.Request.Path = "/api/users/456";
+        httpContext.Request.QueryString = QueryString.Empty;
+
+        var result = CacheKeyGenerator.CreateFromUpstreamRequest(httpContext.Request);
+
+        result.Should().Be("put:https:api.myapp.com:/api/users/456:");
+    }
+
+    [Fact]
+    public void CreateFromDownstreamRequest_ShouldNormalizeToLowerCase()
+    {
+        var request = new HttpRequestMessage()
+        {
+            Method = HttpMethod.Get,
+            RequestUri = new Uri("HTTPS://API.EXAMPLE.COM/PRODUCTS?CATEGORY=ELECTRONICS")
+        };
+        var downstreamRequest = new DownstreamRequest(request);
+
+        var result = CacheKeyGenerator.CreateFromDownstreamRequest(downstreamRequest);
+
+        result.Should().Be("get:https:api.example.com:/products:?category=electronics");
+    }
+
+    [Fact]
+    public void CreateFromUpstreamRequest_ShouldNormalizeToLowerCase()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Method = "GET";
+        httpContext.Request.Scheme = "HTTPS";
+        httpContext.Request.Host = new HostString("API.MYAPP.COM");
+        httpContext.Request.Path = "/API/PRODUCTS";
+        httpContext.Request.QueryString = new QueryString("?CATEGORY=ELECTRONICS");
+
+        var result = CacheKeyGenerator.CreateFromUpstreamRequest(httpContext.Request);
+
+        result.Should().Be("get:https:api.myapp.com:/api/products:?category=electronics");
+    }
+
+    [Fact]
+    public void CreateFromDownstreamRequest_ShouldHandleDifferentHttpMethods()
+    {
+        var methods = new[] { HttpMethod.Get, HttpMethod.Post, HttpMethod.Put, HttpMethod.Delete, HttpMethod.Patch };
+        var expectedMethods = new[] { "get", "post", "put", "delete", "patch" };
+
+        for (int i = 0; i < methods.Length; i++)
+        {
+            var request = new HttpRequestMessage()
+            {
+                Method = methods[i],
+                RequestUri = new Uri("https://api.example.com/test")
+            };
+            var downstreamRequest = new DownstreamRequest(request);
+
+            var result = CacheKeyGenerator.CreateFromDownstreamRequest(downstreamRequest);
+
+            result.Should().StartWith($"{expectedMethods[i]}:");
+        }
+    }
+
+    [Fact]
+    public void CreateFromUpstreamRequest_ShouldHandleDifferentHttpMethods()
+    {
+        var methods = new[] { "GET", "POST", "PUT", "DELETE", "PATCH" };
+        var expectedMethods = new[] { "get", "post", "put", "delete", "patch" };
+
+        for (int i = 0; i < methods.Length; i++)
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Method = methods[i];
+            httpContext.Request.Scheme = "https";
+            httpContext.Request.Host = new HostString("api.example.com");
+            httpContext.Request.Path = "/test";
+            httpContext.Request.QueryString = QueryString.Empty;
+
+            var result = CacheKeyGenerator.CreateFromUpstreamRequest(httpContext.Request);
+
+            result.Should().StartWith($"{expectedMethods[i]}:");
+        }
+    }
+
+    [Fact]
+    public void BothMethods_ShouldGenerateDifferentKeysForSameEndpoint()
+    {
+        // Upstream request
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Method = "GET";
+        httpContext.Request.Scheme = "http";
+        httpContext.Request.Host = new HostString("localhost:5000");
+        httpContext.Request.Path = "/api/products";
+        httpContext.Request.QueryString = new QueryString("?page=1");
+
+        // Downstream request (after Ocelot transformation)
+        var request = new HttpRequestMessage()
+        {
+            Method = HttpMethod.Get,
+            RequestUri = new Uri("http://backend:8080/v1/products?page=1")
+        };
+        var downstreamRequest = new DownstreamRequest(request);
+
+        var upstreamKey = CacheKeyGenerator.CreateFromUpstreamRequest(httpContext.Request);
+        var downstreamKey = CacheKeyGenerator.CreateFromDownstreamRequest(downstreamRequest);
+
+        upstreamKey.Should().Be("get:http:localhost:5000:/api/products:?page=1");
+        downstreamKey.Should().Be("get:http:backend:/v1/products:?page=1");
+        upstreamKey.Should().NotBe(downstreamKey);
+    }
+}

--- a/tests/Kros.Ocelot.ETagCaching.Test/Policies/CacheKeyPolicyShould.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/Policies/CacheKeyPolicyShould.cs
@@ -1,4 +1,5 @@
 ﻿using Kros.Ocelot.ETagCaching.Policies;
+using Microsoft.AspNetCore.Http;
 using Ocelot.Request.Middleware;
 
 namespace Kros.Ocelot.ETagCaching.Test.Policies;
@@ -30,7 +31,8 @@ public class CacheKeyPolicyShould
         await defaultPolicy.ServeNotModifiedAsync(context2, default);
         await extraPropsPolicy.ServeNotModifiedAsync(context2, default);
 
-        context.Should().BeEquivalentTo(context2);
+        context.Should().BeEquivalentTo(context2, o =>
+            o.Excluding(p => p.HttpContext));
     }
 
     [Fact]
@@ -49,6 +51,70 @@ public class CacheKeyPolicyShould
         context.Should().BeEquivalentTo(context2,
             options => options
                 .Excluding(p => p.ResponseHeaders)
-                .Excluding(p => p.ETag));
+                .Excluding(p => p.ETag)
+                .Excluding(p => p.HttpContext));
+    }
+
+    [Fact]
+    public async Task CreateUpstreamCacheKeyInContext_WhenFromUpstreamRequestWithCustomGeneratorWasUsed()
+    {
+        var keyGenerator = new Func<HttpRequest, string>(r => $"custom:{r.Method}:{r.Path}");
+        var policy = CacheKeyPolicy.FromUpstreamRequest(keyGenerator);
+
+        var context = ETagCacheContextFactory.CreateContext(
+            upstreamPath: "/api/1/products",
+            upstreamQuery: "?filter=active");
+        await policy.CacheETagAsync(context, default);
+
+        context.CacheKey.Should().Be("custom:GET:/api/1/products");
+    }
+
+    [Fact]
+    public async Task CreateDefaultUpstreamCacheKeyInContext_WhenFromUpstreamRequestWithoutGeneratorWasUsed()
+    {
+        var policy = CacheKeyPolicy.FromUpstreamRequest();
+
+        var context = ETagCacheContextFactory.CreateContext(
+            httpMethod: "POST",
+            upstreamPath: "/api/1/orders",
+            upstreamQuery: "?include=details");
+        await policy.CacheETagAsync(context, default);
+
+        var expectedKey = "post:http:localhost:5000:/api/1/orders:?include=details";
+        context.CacheKey.Should().Be(expectedKey);
+    }
+
+    [Fact]
+    public async Task CreateUpstreamCacheKey_WithEmptyQueryString()
+    {
+        var policy = CacheKeyPolicy.FromUpstreamRequest();
+
+        var context = ETagCacheContextFactory.CreateContext(
+            upstreamPath: "/api/1/users",
+            upstreamQuery: "");
+        await policy.CacheETagAsync(context, default);
+
+        var expectedKey = "get:http:localhost:5000:/api/1/users:";
+        context.CacheKey.Should().Be(expectedKey);
+    }
+
+    [Fact]
+    public async Task CreateUpstreamCacheKey_WithDifferentHttpMethods()
+    {
+        var policy = CacheKeyPolicy.FromUpstreamRequest();
+
+        var getContext = ETagCacheContextFactory.CreateContext(
+            httpMethod: "GET",
+            upstreamPath: "/api/1/products");
+        await policy.CacheETagAsync(getContext, default);
+
+        var postContext = ETagCacheContextFactory.CreateContext(
+            httpMethod: "POST",
+            upstreamPath: "/api/1/products");
+        await policy.CacheETagAsync(postContext, default);
+
+        getContext.CacheKey.Should().StartWith("get:");
+        postContext.CacheKey.Should().StartWith("post:");
+        getContext.CacheKey.Should().NotBe(postContext.CacheKey);
     }
 }

--- a/tests/Kros.Ocelot.ETagCaching.Test/Policies/ETagPolicyShould.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/Policies/ETagPolicyShould.cs
@@ -30,7 +30,8 @@ public class ETagPolicyShould
         await defaultPolicy.ServeNotModifiedAsync(context2, default);
         await extraPropsPolicy.ServeNotModifiedAsync(context2, default);
 
-        context.Should().BeEquivalentTo(context2);
+        context.Should().BeEquivalentTo(context2,
+            o => o.Excluding(p => p.HttpContext));
     }
 
     [Fact]
@@ -49,6 +50,7 @@ public class ETagPolicyShould
         context.Should().BeEquivalentTo(context2,
             options => options
                 .Excluding(p => p.ResponseHeaders)
-                .Excluding(p => p.ETag));
+                .Excluding(p => p.ETag)
+                .Excluding(p=> p.HttpContext));
     }
 }

--- a/tests/Kros.Ocelot.ETagCaching.Test/Policies/EmptyPolicyShould.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/Policies/EmptyPolicyShould.cs
@@ -17,7 +17,8 @@ public class EmptyPolicyShould
         await defaultPolicy.CacheETagAsync(context2, default);
         await emptyPolicy.CacheETagAsync(context2, default);
 
-        context.Should().BeEquivalentTo(context2);
+        context.Should().BeEquivalentTo(context2, o =>
+            o.Excluding(p => p.HttpContext));
     }
 
     [Fact]
@@ -33,7 +34,8 @@ public class EmptyPolicyShould
         await defaultPolicy.ServeNotModifiedAsync(context2, default);
         await emptyPolicy.ServeNotModifiedAsync(context2, default);
 
-        context.Should().BeEquivalentTo(context2);
+        context.Should().BeEquivalentTo(context2, o =>
+            o.Excluding(p => p.HttpContext));
     }
 
     [Fact]
@@ -52,6 +54,7 @@ public class EmptyPolicyShould
         context.Should().BeEquivalentTo(context2, options
             => options
                 .Excluding(p => p.ResponseHeaders)
-                .Excluding(p=> p.ETag));
+                .Excluding(p=> p.ETag)
+                .Excluding(p => p.HttpContext));
     }
 }

--- a/tests/Kros.Ocelot.ETagCaching.Test/Policies/ExpirationPolicyShould.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/Policies/ExpirationPolicyShould.cs
@@ -28,7 +28,8 @@ public class ExpirationPolicyShould
         await defaultPolicy.ServeNotModifiedAsync(context2, default);
         await extraPropsPolicy.ServeNotModifiedAsync(context2, default);
 
-        context.Should().BeEquivalentTo(context2);
+        context.Should().BeEquivalentTo(context2,
+            o => o.Excluding(p => p.HttpContext));
     }
 
     [Fact]
@@ -47,6 +48,7 @@ public class ExpirationPolicyShould
         context.Should().BeEquivalentTo(context2,
             options => options
                 .Excluding(p => p.ResponseHeaders)
-                .Excluding(p => p.ETag));
+                .Excluding(p => p.ETag)
+                .Excluding(p => p.HttpContext));
     }
 }

--- a/tests/Kros.Ocelot.ETagCaching.Test/Policies/StatusCodePolicyShould.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/Policies/StatusCodePolicyShould.cs
@@ -51,7 +51,6 @@ public class StatusCodePolicyShould
 
         context.Should().BeEquivalentTo(context2,
             o => o
-                .Excluding(p => p.ResponseHeaders)
                 .Excluding(p => p.HttpContext));
     }
 }

--- a/tests/Kros.Ocelot.ETagCaching.Test/Policies/StatusCodePolicyShould.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/Policies/StatusCodePolicyShould.cs
@@ -32,7 +32,8 @@ public class StatusCodePolicyShould
         context.Should().BeEquivalentTo(context2,
             options => options
                 .Excluding(p => p.ResponseHeaders)
-                .Excluding(p => p.ETag));
+                .Excluding(p => p.ETag)
+                .Excluding(p => p.HttpContext));
     }
 
     [Fact]
@@ -48,6 +49,9 @@ public class StatusCodePolicyShould
         await defaultPolicy.CacheETagAsync(context2, default);
         await extraPropsPolicy.CacheETagAsync(context2, default);
 
-        context.Should().BeEquivalentTo(context2);
+        context.Should().BeEquivalentTo(context2,
+            o => o
+                .Excluding(p => p.ResponseHeaders)
+                .Excluding(p => p.HttpContext));
     }
 }

--- a/tests/Kros.Ocelot.ETagCaching.Test/Policies/TagTemplatesPolicyShould.cs
+++ b/tests/Kros.Ocelot.ETagCaching.Test/Policies/TagTemplatesPolicyShould.cs
@@ -29,7 +29,8 @@ public class TagTemplatesPolicyShould
         await defaultPolicy.ServeNotModifiedAsync(context2, default);
         await extraPropsPolicy.ServeNotModifiedAsync(context2, default);
 
-        context.Should().BeEquivalentTo(context2);
+        context.Should().BeEquivalentTo(context2,
+            o => o.Excluding(p => p.HttpContext));
     }
 
     [Fact]
@@ -49,6 +50,7 @@ public class TagTemplatesPolicyShould
         context.Should().BeEquivalentTo(context2,
             options => options
                 .Excluding(p => p.ResponseHeaders)
-                .Excluding(p => p.ETag));
+                .Excluding(p => p.ETag)
+                .Excluding(p => p.HttpContext));
     }
 }

--- a/tests/Kros.Ocelot.ETagCaching.Test/PublicApiTests.Assembly_Has_No_Public_Api_Changes.verified.txt
+++ b/tests/Kros.Ocelot.ETagCaching.Test/PublicApiTests.Assembly_Has_No_Public_Api_Changes.verified.txt
@@ -24,6 +24,8 @@ namespace Kros.Ocelot.ETagCaching
         [System.Runtime.CompilerServices.RequiredMember]
         public Ocelot.Request.Middleware.DownstreamRequest DownstreamRequest { get; init; }
         [System.Runtime.CompilerServices.RequiredMember]
+        public Microsoft.AspNetCore.Http.HttpContext HttpContext { get; init; }
+        [System.Runtime.CompilerServices.RequiredMember]
         public Microsoft.AspNetCore.Http.Features.IFeatureCollection RequestFeatures { get; init; }
         [System.Runtime.CompilerServices.RequiredMember]
         public System.IServiceProvider RequestServices { get; init; }
@@ -47,6 +49,8 @@ namespace Kros.Ocelot.ETagCaching
         public Kros.Ocelot.ETagCaching.ETagCachePolicyBuilder Expire(System.TimeSpan expiration) { }
         public Kros.Ocelot.ETagCaching.ETagCachePolicyBuilder StatusCode(int statusCode) { }
         public Kros.Ocelot.ETagCaching.ETagCachePolicyBuilder TagTemplates(params string[] tagTemplates) { }
+        public Kros.Ocelot.ETagCaching.ETagCachePolicyBuilder UpstreamCacheKey() { }
+        public Kros.Ocelot.ETagCaching.ETagCachePolicyBuilder UpstreamCacheKey(System.Func<Microsoft.AspNetCore.Http.HttpRequest, string> keyGenerator) { }
     }
     public sealed class ETagCachingOptions
     {


### PR DESCRIPTION
# Add Upstream Cache Key Generation Support

## Overview
This PR adds support for generating cache keys from the original upstream HTTP request (before Ocelot transformation) in addition to the existing downstream cache key generation.

## Changes Made

### Core Implementation
- **Extended `ETagCacheContext`**: Added `HttpContext` property to provide access to the original HTTP request
- **Enhanced `CacheKeyPolicy`**: 
  - Refactored to use `Func<ETagCacheContext, string>` internally
  - Added factory methods `FromUpstreamRequest()` and `FromUpstreamRequest(Func<HttpRequest, string>)`
  - Created `CreateUpstreamCacheKey()` helper method
- **Extended `ETagCachePolicyBuilder`**: Added `UpstreamCacheKey()` methods for fluent API
- **Updated `ETagCachingMiddleware`**: Modified to set `HttpContext` in cache context

## API Usage

### Default upstream cache key (method:scheme:host:path:query)

```csharp
p.UpstreamCacheKey();
```

### Custom upstream cache key generator

```csharp
p.UpstreamCacheKey(request => $"custom:{request.Method}:{request.Path}");
```

## Use Cases
- **Multi-tenant applications**: When upstream path contains tenant information
- **Cache key consistency**: When downstream transformation changes important cache components
- **Original request tracking**: When you need cache keys based on client's original request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for generating cache keys from the original (upstream) HTTP request, providing more flexibility in ETag caching configuration.
  - Introduced new methods for customizing upstream cache key generation, including both default and user-defined formats.

- **Documentation**
  - Updated the README with examples and a new section explaining cache key generation modes and customization options.

- **Bug Fixes**
  - Improved test assertions to ignore irrelevant differences in HTTP context, ensuring more accurate test results.

- **Tests**
  - Added comprehensive unit tests to verify upstream cache key generation and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->